### PR TITLE
chore: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ import { raw } from "esbuild-raw-plugin";
 export default defineConfig({
   entry: ["src/index.ts"],
   outDir: "dist",
-  plugins: [raw()],
+  esbuildPlugins: [raw()],
 });
 ```
 


### PR DESCRIPTION
`tsup` requires to pass this plugin through `esbuildPlugins` option, otherwise it won't work :

![image](https://github.com/user-attachments/assets/a44a5057-6763-40a4-ae2d-ffbfda9f80e6)
